### PR TITLE
Attempt to fix layer ordering

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -19,11 +19,11 @@ reexport_line=$((${reexport_line} - 1))
 if [[ ! -z ${reexport_line} ]]
 then
     sed -i.bak "${reexport_line}a\\
-        Planets3d: () => (_render_globals_js__WEBPACK_IMPORTED_MODULE_X__.Planets3d),
+        Planets3d: () => (_render_globals_js__WEBPACK_IMPORTED_MODULE_X__.Planets3d), BasePlanets: () => (_render_globals_js__WEBPACK_IMPORTED_MODULE_Y__.BasePlanets),
     " ${filepath}
     import_line=$((reexport_line + 5))
     sed -i.bak "${import_line}a\\
-        var _render_globals_js__WEBPACK_IMPORTED_MODULE_X__ = __webpack_require__('./esm/planets_3d.js'); 
+    var _render_globals_js__WEBPACK_IMPORTED_MODULE_X__ = __webpack_require__('./esm/planets_3d.js'); var _render_globals_js__WEBPACK_IMPORTED_MODULE_Y__ = __webpack_require__('./esm/baseplanets.js');
     " ${filepath}
     rm ${filepath}.bak
 fi

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -335,6 +335,7 @@ function doWWTHacks() {
   // @ts-expect-error this does exist
   SpreadSheetLayer.prototype.draw = spreadSheetLayerDraw;
 
+  // @ts-expect-error this does exist
   BasePlanets.drawPointPlanet = drawPointPlanet;
 }
 

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -228,60 +228,13 @@ import InformationSheet from "./components/InformationSheet.vue";
 import WebGlTest from "./components/WebGlTest.vue";
 const webglDisabled = ref(false);
 
-const ZOOM_MIN   = 0.00006;
-const ZOOM_MAX   = 240;
-const LOG_MIN    = Math.log(ZOOM_MIN);
-const LOG_MAX    = Math.log(ZOOM_MAX);
-// Power < 1 stretches the small-fov (zoomed-in) end of the slider.
-const ZOOM_POWER = 3.5;
+import { useScaledZoom } from "./composables/useScaledZoom";
+const { zoomSliderValue, onZoomSlider, zoomIn, zoomOut, ZOOM_MAX, ZOOM_MIN } = useScaledZoom();
 
-// Map linear slider position [0,1] → stretched slider position [0,1].
-const stretchSlider   = (t: number) => Math.pow(t, ZOOM_POWER);
-// Inverse: stretched slider position → linear slider position.
-const unstretchSlider = (t: number) => Math.pow(t, 1 / ZOOM_POWER);
 
-function fovToSlider(fov: number): number {
-  const linear = (Math.log(fov) - LOG_MIN) / (LOG_MAX - LOG_MIN);
-  return unstretchSlider(linear);
-}
-function sliderToFov(t: number): number {
-  return Math.exp(LOG_MIN + stretchSlider(t) * (LOG_MAX - LOG_MIN));
-}
 
-const zoomSliderValue = computed(() => fovToSlider(store.zoomDeg));
-
-function onZoomSlider(e: Event) {
-  const fov = sliderToFov(+(e.target as HTMLInputElement).value);
-  const rc = WWTControl.singleton.renderContext;
-  rc.targetCamera.zoom = fov;
-  rc.viewCamera.zoom   = fov;
-  WWTControl.singleton.renderOneFrame();
-}
-
-function zoomIn() {
-  const newZoom = store.zoomDeg / 1.25;
-  const clampedZoom = Math.max(newZoom, ZOOM_MIN);
-  const rc = WWTControl.singleton.renderContext;
-  rc.targetCamera.zoom = clampedZoom;
-  rc.viewCamera.zoom   = clampedZoom;
-  WWTControl.singleton.renderOneFrame();
-}
-
-function zoomOut() {
-  const newZoom = store.zoomDeg * 1.25;
-  const clampedZoom = Math.min(newZoom, ZOOM_MAX);
-  const rc = WWTControl.singleton.renderContext;
-  rc.targetCamera.zoom = clampedZoom;
-  rc.viewCamera.zoom   = clampedZoom;
-  WWTControl.singleton.renderOneFrame();
-}
-
-type SheetType = "text" | "video";
-
-type CameraParams = Omit<GotoRADecZoomParams, "instant">;
 export interface WwtPlaygroundProps {
   wwtNamespace?: string;
-  initialCameraParams?: CameraParams;
 }
 
 const fullscreen = useFullscreen();
@@ -300,14 +253,6 @@ const { smAndDown } = useDisplay();
 
 const props = withDefaults(defineProps<WwtPlaygroundProps>(), {
   wwtNamespace: "wwt-playground",
-  initialCameraParams: () => {
-    const galacticCenter = AstroCalc.galacticToJ2000(0, 0);
-    return {
-      raRad: galacticCenter.RA * H2R ,
-      decRad: galacticCenter.dec * D2R,
-      zoomDeg: 360
-    };
-  }
 });
 
 

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -154,6 +154,9 @@
             v-model:time="currentTime"
             :can-create="positionSet"
             :initial-time="INITIAL_TIME"
+            :start-time="MISSION_START"
+            :end-time="MISSION_END"
+            :step="horizonTimeDelta"
           />
           <div
             v-if="smallSize"
@@ -231,6 +234,9 @@ const webglDisabled = ref(false);
 import { useScaledZoom } from "./composables/useScaledZoom";
 const { zoomSliderValue, onZoomSlider, zoomIn, zoomOut, ZOOM_MAX, ZOOM_MIN } = useScaledZoom();
 
+import { clampedTime } from "./utils";
+import horizonsData from "@/assets/horizons_results-earth.txt?raw";
+import { getHorizonsStartEndTimes } from "./horizons";
 
 
 export interface WwtPlaygroundProps {
@@ -268,13 +274,11 @@ const buttonColor = ref("#ffffff");
 const VIDEO_URL = "https://www.youtube.com/embed/ML9y0Z7A8ec?autoplay=1&mute=1";
 
 
-// 2026-Apr-02 01:59:00.0000
-const MISSION_START = new Date("2026-04-02T01:59:00Z");
-// 2026-Apr-10 23:54:00.0000
-const MISSION_END   = new Date("2026-04-10T23:54:00Z");
-// HOME_TIME shoul be clamped as now between START and END
-const now = new Date();
-const HOME_TIME = new Date(Math.min(Math.max(now.getTime(), MISSION_START.getTime()), MISSION_END.getTime()));
+
+
+
+const { start: MISSION_START, end: MISSION_END, deltaT: horizonTimeDelta } = getHorizonsStartEndTimes(horizonsData);
+const HOME_TIME = clampedTime(new Date(), MISSION_START, MISSION_END);
 const urlTime = new URLSearchParams(window.location.search).get("time");
 
 
@@ -337,7 +341,7 @@ const trackingCenter = ref<SolarSystemObjects>(SolarSystemObjects.moon);
 
 const showTrajectory = ref(true);
 
-import horizonsData from "@/assets/horizons_results-earth.txt?raw";
+
 
 
 import { OrbitLineList, Vector3d } from "@wwtelescope/engine";

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -498,7 +498,7 @@ onMounted(() => {
     
   
     // @ts-expect-error this does exist
-    WWTControl.singleton.shallowLayerTest = function(layer) {
+    WWTControl.singleton.shallowLayerTest = function(_layer) {
       return true;
       // const table = layer.get__table();
       // const rows = table.rows;

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -243,7 +243,7 @@ import {
 import { clampedTime } from "./utils";
 
 
-import { parseHorizonsVectorsForWwt, getHorizonsStartEndTimes } from "./horizons";
+import { parseHorizonsVectorsForWwt, getHorizonsStartEndTimes, setupHorizonsSpreadSheetLayer } from "./horizons";
 import horizonsData from "@/assets/horizons_results-earth.txt?raw";
 
 import { useScaledZoom } from "./composables/useScaledZoom";
@@ -382,6 +382,13 @@ function createArtemisOrbitLineList(trackedObject: SolarSystemObjects) {
 }
 
 
+function createHorizonsSpreadSheetLayer(name: string, dataCsv: string, referenceFrame: string = 'Sky') {
+  return store.createTableLayer({
+    name,
+    referenceFrame: referenceFrame,
+    dataCsv,
+  }).then(setupHorizonsSpreadSheetLayer);
+};
 
 function createArtemisLayers(trackedObject: SolarSystemObjects) {
   const vec =   parseHorizonsVectorsForWwt(horizonsData, SolarSystemObjects.earth, trackedObject);
@@ -400,30 +407,20 @@ function createArtemisLayers(trackedObject: SolarSystemObjects) {
   bounds.forEach((bds) => {
     const data = items.slice(...bds).join("\r\n");
 
-    store.createTableLayer({
-      name: 'Artemis Time',
-      referenceFrame: 'Sky',
-      dataCsv: `${header}\r\n${data}`,
-    }).then(layer => {
-      layer.set_xAxisColumn(2);
-      layer.set_yAxisColumn(3);
-      layer.set_zAxisColumn(4);
-      layer.set_coordinatesType(CoordinatesType.rectangular);
-      layer.set_astronomical(true);
-      layer.set_cartesianScale(AltUnits.astronomicalUnits);
-      layer.set_altUnit(AltUnits.astronomicalUnits);
-      layer.set_markerScale(MarkerScales.screen);
-      layer.set_plotType(PlotTypes.gaussian);
-      layer.set_scaleFactor(25);
-      layer.set_color(Color.fromHex("#df1c23")); // artemis
-      layer.set_showFarSide(true);
-      layer.set_opacity(100);
-      layer.set_startDateColumn(1);
-      layer.set_endDateColumn(1);
-      layer.set_decay(4.9 / (60 * 24));
-      layer.set_timeSeries(true);
-      layers.value.push(layer);
-    });
+    createHorizonsSpreadSheetLayer('Artemis Time', `${header}\r\n${data}`, 'Sky')
+      .then(layer => {
+        layer.set_markerScale(MarkerScales.screen);
+        layer.set_plotType(PlotTypes.gaussian);
+        layer.set_scaleFactor(25);
+        layer.set_color(Color.fromHex("#df1c23")); // artemis
+        layer.set_showFarSide(true);
+        layer.set_opacity(100);
+        layer.set_startDateColumn(1);
+        layer.set_endDateColumn(1);
+        layer.set_decay(4.9 / (60 * 24));
+        layer.set_timeSeries(true);
+        layers.value.push(layer);
+      });
   });
 }
 

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -397,23 +397,23 @@ function createArtemisLayers(trackedObject: SolarSystemObjects) {
   const vec =   parseHorizonsVectorsForWwt(horizonsData, SolarSystemObjects.earth, trackedObject);
   
   // REMOVE: temp for degugging layer order
-  createHorizonsSpreadSheetLayer('Artemis', vec, 'Sky')
-    .then(layer => {
-      layer.set_markerScale(MarkerScales.screen);
-      layer.set_plotType(PlotTypes.gaussian);
-      layer.set_scaleFactor(20);
-      layer.set_color(Color.fromHex("#ffffff")); // artemis
-      layer.set_showFarSide(true);
-      layer.set_opacity(100);
-      layers.value.push(layer);
-    });
+  // createHorizonsSpreadSheetLayer('Artemis', vec, 'Sky')
+  //   .then(layer => {
+  //     layer.set_markerScale(MarkerScales.world);
+  //     layer.set_plotType(PlotTypes.gaussian);
+  //     layer.set_scaleFactor(0.0012);
+  //     layer.set_color(Color.fromHex("#ffffff")); // artemis
+  //     layer.set_showFarSide(true);
+  //     layer.set_opacity(100);
+  //     layers.value.push(layer);
+  //   });
     
   
   createHorizonsSpreadSheetLayer('Artemis Time', vec, 'Sky')
     .then(layer => {
       layer.set_markerScale(MarkerScales.screen);
       layer.set_plotType(PlotTypes.gaussian);
-      layer.set_scaleFactor(40);
+      layer.set_scaleFactor(25);
       layer.set_color(Color.fromHex("#df1c23")); // artemis
       layer.set_showFarSide(true);
       layer.set_opacity(100);

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -500,19 +500,6 @@ onMounted(() => {
     // @ts-expect-error this does exist
     WWTControl.singleton.shallowLayerTest = function(_layer) {
       return true;
-      // const table = layer.get__table();
-      // const rows = table.rows;
-      // const count = rows.length;
-      // const center = Math.floor(count / 2);
-      // const centerRow = rows[center];
-      // const x = Number(centerRow[layer.get_xAxisColumn()]);
-      // const y = Number(centerRow[layer.get_yAxisColumn()]);
-      // const z = Number(centerRow[layer.get_zAxisColumn()]);
-      // // @ts-expect-error this does exist
-      // const depth = WWTControl.singleton.getDepth(x, y, z);
-      // // @ts-expect-error this does exist
-      // const moonDepth = WWTControl.singleton.getDepth(0, 0, 0);
-      // return depth <= (moonDepth + 0.0000116 / 6); // magic number minor improvement to front side depth test
     }.bind(this);
 
     

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -206,37 +206,48 @@
 </template>
 
 <script setup lang="ts">
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { ref, reactive, computed, onMounted, watch } from "vue";
-import { GotoRADecZoomParams, engineStore } from "@wwtelescope/engine-pinia";
-import { BackgroundImageset, supportsTouchscreen, useWWTKeyboardControls, CreditLogos, IconButton, useFullscreen } from "@cosmicds/vue-toolkit";
+import { ref, computed, onMounted, watch } from "vue";
+import { engineStore } from "@wwtelescope/engine-pinia";
+import { supportsTouchscreen, useWWTKeyboardControls, CreditLogos, IconButton, useFullscreen } from "@cosmicds/vue-toolkit";
 import { useDisplay } from "vuetify";
-import { D2R, H2R  } from "@wwtelescope/astro";
-import { AstroCalc, Color, SpreadSheetLayer } from "@wwtelescope/engine";
-import { CoordinatesType, MarkerScales, PlotTypes, ReferenceFrames, SolarSystemObjects } from "@wwtelescope/engine-types";
+import { Color, SpreadSheetLayer, OrbitLineList, LayerManager, WWTControl, Vector3d } from "@wwtelescope/engine";
+import { CoordinatesType, MarkerScales, PlotTypes, SolarSystemObjects, AltUnits } from "@wwtelescope/engine-types";
+
+/* Component imports */
 import ArtemisTimeControl from "./components/ArtemisTimeControl.vue";
 import VideoWrapper from "./components/VideoWrapper.vue";
-import GesturePreview from "./components/GesturePreview.vue";
 import SplashGesture from "./components/SplashGesture.vue";
-
-import { useCameraUrl } from "./composables/useCameraUrl";
-import { moveViewCamera, layerManagerDraw, getDepth, getCoordinatesForScreenPoint,getScreenPointForCoordinates, transformPickPointToWorldSpace, transformWorldPointToPickSpace, renderOneFrame, makeFrustum, type CameraView } from "./wwt-hacks";
-import { LayerManager, WWTControl } from "@wwtelescope/engine";
-import { AltUnits } from "@wwtelescope/engine-types";
-
-import { parseHorizonsVectorsForWwt } from "./horizons";
 import SplashScreen from "./components/SplashScreen.vue";
 import InformationSheet from "./components/InformationSheet.vue";
+
 
 import WebGlTest from "./components/WebGlTest.vue";
 const webglDisabled = ref(false);
 
-import { useScaledZoom } from "./composables/useScaledZoom";
-const { zoomSliderValue, onZoomSlider, zoomIn, zoomOut, ZOOM_MAX, ZOOM_MIN } = useScaledZoom();
-
+/* local imports */
+import { useCameraUrl } from "./composables/useCameraUrl";
+import { 
+  moveViewCamera, 
+  layerManagerDraw, 
+  getDepth, 
+  getCoordinatesForScreenPoint,
+  getScreenPointForCoordinates, 
+  transformPickPointToWorldSpace, 
+  transformWorldPointToPickSpace, 
+  renderOneFrame,
+  makeFrustum, 
+  addToWWTRenderLoop,
+  removeFromWWTRenderLoop,
+  type CameraView 
+} from "./wwt-hacks";
 import { clampedTime } from "./utils";
+
+
+import { parseHorizonsVectorsForWwt, getHorizonsStartEndTimes } from "./horizons";
 import horizonsData from "@/assets/horizons_results-earth.txt?raw";
-import { getHorizonsStartEndTimes } from "./horizons";
+
+import { useScaledZoom } from "./composables/useScaledZoom";
+const { zoomSliderValue, onZoomSlider, zoomIn, zoomOut, ZOOM_MAX } = useScaledZoom();
 
 
 export interface WwtPlaygroundProps {
@@ -254,15 +265,17 @@ const store = engineStore();
 
 useWWTKeyboardControls(store);
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const touchscreen = supportsTouchscreen();
 const { smAndDown } = useDisplay();
 
-const props = withDefaults(defineProps<WwtPlaygroundProps>(), {
+// the prop get automatically destructed and is available in the <template>
+withDefaults(defineProps<WwtPlaygroundProps>(), {
   wwtNamespace: "wwt-playground",
 });
 
 
-const backgroundImagesets = reactive<BackgroundImageset[]>([]);
+
 const showInfoSheet = ref(false);
 const showSplashScreen = ref(true);
 const splashIsClosed = ref(false);
@@ -281,10 +294,10 @@ const { start: MISSION_START, end: MISSION_END, deltaT: horizonTimeDelta } = get
 const HOME_TIME = clampedTime(new Date(), MISSION_START, MISSION_END);
 const urlTime = new URLSearchParams(window.location.search).get("time");
 
-
-
 const INITIAL_TIME = ref(urlTime ? new Date(+urlTime) : HOME_TIME);
-// ?lng=214.660687&lat=13.418963&fov=0.000511&rot=0.000000&angle=0.000000&time=1775514752592
+const currentTime = ref(INITIAL_TIME.value);
+
+
 const INITIAL_VIEW: CameraView = {
   lng: 214.660687,
   lat: 13.418963,
@@ -294,26 +307,17 @@ const INITIAL_VIEW: CameraView = {
   time: INITIAL_TIME.value.getTime()
 };
 
-// http://localhost:5174/?lng=316.555988&lat=74.277000&fov=0.017202&rot=0.000000&angle=0.000000&time=1775474823266
 const EARTH_VIEW: CameraView = {
   lng: 316.555988,
   lat: 74.277000,
   zoomDeg: 0.017202,
   rotationDeg: 0,
   angleDeg: 0,
-  time: 1775474823266
+  time: INITIAL_TIME.value.getTime() // this doesn't actually get used
 };
 
-const { copyViewUrl, copySuccess } = useCameraUrl(INITIAL_VIEW);
+const { copyViewUrl, copySuccess, afterInitialized } = useCameraUrl(INITIAL_VIEW);
 
-
-const currentTime = ref(INITIAL_TIME.value);
-
-function goHome() {
-  currentTime.value = INITIAL_TIME.value;
-  trackingCenter.value = SolarSystemObjects.moon;
-  moveViewCamera(INITIAL_VIEW, false);
-}
 
 function doWWTHacks() {
   WWTControl.singleton.getScreenPointForCoordinates = getScreenPointForCoordinates.bind(WWTControl.singleton);
@@ -341,10 +345,15 @@ const trackingCenter = ref<SolarSystemObjects>(SolarSystemObjects.moon);
 
 const showTrajectory = ref(true);
 
+const showSkyBackground = ref(true);
+
+function goHome() {
+  currentTime.value = INITIAL_TIME.value;
+  trackingCenter.value = SolarSystemObjects.moon;
+  moveViewCamera(INITIAL_VIEW, false);
+}
 
 
-
-import { OrbitLineList, Vector3d } from "@wwtelescope/engine";
 function createArtemisOrbitLineList(trackedObject: SolarSystemObjects) {
   const lineList = new OrbitLineList();
   const colorHex = "#ffffff";
@@ -352,7 +361,7 @@ function createArtemisOrbitLineList(trackedObject: SolarSystemObjects) {
   color.a = 255;
   const vec = parseHorizonsVectorsForWwt(horizonsData, SolarSystemObjects.earth, trackedObject);
   const items = vec.split("\r\n");
-  const header = items.shift();
+  // const header = items.shift();
   const points = items.map(line => {
     const parts = line.split(",");
     return Vector3d.create(
@@ -375,7 +384,6 @@ function createArtemisOrbitLineList(trackedObject: SolarSystemObjects) {
 
 
 function createArtemisLayers(trackedObject: SolarSystemObjects) {
-
   const vec =   parseHorizonsVectorsForWwt(horizonsData, SolarSystemObjects.earth, trackedObject);
   const items = vec.split("\r\n");
   const header = items.shift();
@@ -391,31 +399,6 @@ function createArtemisLayers(trackedObject: SolarSystemObjects) {
   bounds = [[0, centerStart], ...bounds, [centerEnd, end]];
   bounds.forEach((bds) => {
     const data = items.slice(...bds).join("\r\n");
-
-    // if (showTrajectory.value) {
-    //   store.createTableLayer({
-    //     name: 'Artemis',
-    //     referenceFrame: 'Sky',
-    //     dataCsv: `${header}\r\n${data}`,
-    //   }).then(layer => {
-    //     layer.set_xAxisColumn(2);
-    //     layer.set_yAxisColumn(3);
-    //     layer.set_zAxisColumn(4);
-    //     layer.set_coordinatesType(CoordinatesType.rectangular);
-    //     layer.set_astronomical(true);
-    //     layer.set_cartesianScale(AltUnits.astronomicalUnits);
-    //     layer.set_altUnit(AltUnits.astronomicalUnits);
-    //     layer.set_markerScale(MarkerScales.screen);
-    //     // layer.set_scaleFactor(.0012);
-    //     layer.set_scaleFactor(10);
-    //     layer.set_color(Color.fromHex("#ffffff"));
-    //     layer.set_showFarSide(true);
-    //     layer.set_opacity(25);
-    //     layers.value.push(layer);
-    //   });
-    // }
-
-
 
     store.createTableLayer({
       name: 'Artemis Time',
@@ -441,14 +424,8 @@ function createArtemisLayers(trackedObject: SolarSystemObjects) {
       layer.set_timeSeries(true);
       layers.value.push(layer);
     });
-    
-    
   });
-
-
 }
-
-
 
 function removeArtemisLayers() {
   console.log('remove layers');
@@ -456,22 +433,30 @@ function removeArtemisLayers() {
   layers.value = [];
 }
 
-const showSkyBackground = ref(true);
 
 
-import { addToWWTRenderLoop, removeFromWWTRenderLoop } from "./wwt-hacks";
-const artemisOrbitLineList = ref(createArtemisOrbitLineList(trackingCenter.value));
+
+const artemisOrbitLineList = ref<OrbitLineList | null>(null);
 
 function setArtemisLineList() {
   artemisOrbitLineList.value = createArtemisOrbitLineList(trackingCenter.value);
 }
 function drawArtemisOrbit () {
-  if (showTrajectory.value) {
+  if (showTrajectory.value && artemisOrbitLineList.value) {
     artemisOrbitLineList.value.set_depthBuffered(true);
     artemisOrbitLineList.value.drawLines(WWTControl.singleton.renderContext, 1, Color.fromHex("#ffffff"));
   }
 }
 
+function createArtemisOrbit() {
+  setArtemisLineList();
+  addToWWTRenderLoop(() => {
+    drawArtemisOrbit();
+  });
+}
+function removeArtemisOrbit() {
+  removeFromWWTRenderLoop(drawArtemisOrbit);
+}
 
 onMounted(() => {
   
@@ -497,12 +482,9 @@ onMounted(() => {
     store.applySetting(["solarSystemCosmos", true]);
     store.applySetting(["solarSystemMilkyWay", showSkyBackground.value]);
     store.applySetting(["solarSystemStars", showSkyBackground.value]);
-    store.setTrackedObject(SolarSystemObjects.moon);
+    store.setTrackedObject(trackingCenter.value);
     
-    addToWWTRenderLoop(() => {
-      drawArtemisOrbit();
-    });
-
+  
     // @ts-expect-error this does exist
     WWTControl.singleton.shallowLayerTest = function(layer) {
       const table = layer.get__table();
@@ -520,13 +502,14 @@ onMounted(() => {
       return depth <= (moonDepth + 0.0000116 / 6); // magic number minor improvement to front side depth test
     }.bind(this);
 
-
-    store.setTrackedObject(trackingCenter.value);
+    
+    createArtemisOrbit();
     createArtemisLayers(trackingCenter.value);
 
 
-    
-    positionSet.value = true;
+    afterInitialized.then(() => {
+      positionSet.value = true;
+    });
     layersLoaded.value = true;
   });
 });
@@ -542,22 +525,19 @@ watch(showSkyBackground, (show) => {
 
 watch(trackingCenter, (trackedObject) => {
   removeArtemisLayers();
+  removeArtemisOrbit();
   store.setTrackedObject(trackedObject);
   if (trackedObject === SolarSystemObjects.earth) {
     moveViewCamera(EARTH_VIEW, false);
   }
   createArtemisLayers(trackedObject);
-  removeFromWWTRenderLoop(drawArtemisOrbit);
-  setArtemisLineList();
-  addToWWTRenderLoop(drawArtemisOrbit);
+  createArtemisOrbit();
 });
 
-watch(showTrajectory, (show) => {
+watch(showTrajectory, (_show) => {
   removeArtemisLayers();
+  removeArtemisOrbit();
   createArtemisLayers(trackingCenter.value);
-  removeFromWWTRenderLoop(drawArtemisOrbit);
-  setArtemisLineList();
-  addToWWTRenderLoop(drawArtemisOrbit);
 });
 
 const ready = computed(() => layersLoaded.value && positionSet.value);

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -396,7 +396,7 @@ function createArtemisLayers(trackedObject: SolarSystemObjects) {
   const header = items.shift();
   let bounds: [number, number][] = [];
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const N = 2;
+  const N = 10;
   const centerStart = 1300;
   const centerEnd = 1500;
   const end = items.length;
@@ -407,6 +407,18 @@ function createArtemisLayers(trackedObject: SolarSystemObjects) {
   bounds.forEach((bds) => {
     const data = items.slice(...bds).join("\r\n");
 
+    // REMOVE: temp for degugging layer order
+    createHorizonsSpreadSheetLayer('Artemis Time', `${header}\r\n${data}`, 'Sky')
+      .then(layer => {
+        layer.set_markerScale(MarkerScales.world);
+        layer.set_plotType(PlotTypes.gaussian);
+        layer.set_scaleFactor(0.0012);
+        layer.set_color(Color.fromHex("#00ffff")); // artemis
+        layer.set_showFarSide(true);
+        layer.set_opacity(100);
+        layers.value.push(layer);
+      });
+    
     createHorizonsSpreadSheetLayer('Artemis Time', `${header}\r\n${data}`, 'Sky')
       .then(layer => {
         layer.set_markerScale(MarkerScales.screen);

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -238,6 +238,7 @@ import {
   makeFrustum, 
   addToWWTRenderLoop,
   removeFromWWTRenderLoop,
+  spreadSheetLayerDraw,
   type CameraView 
 } from "./wwt-hacks";
 import { clampedTime } from "./utils";
@@ -333,6 +334,8 @@ function doWWTHacks() {
   WWTControl.singleton.renderContext.makeFrustum = makeFrustum.bind(WWTControl.singleton.renderContext);
   // @ts-expect-error this does exist
   LayerManager._draw = layerManagerDraw;
+  // @ts-expect-error this does exist
+  SpreadSheetLayer.prototype.draw = spreadSheetLayerDraw;
 }
 
 
@@ -408,12 +411,12 @@ function createArtemisLayers(trackedObject: SolarSystemObjects) {
     const data = items.slice(...bds).join("\r\n");
 
     // REMOVE: temp for degugging layer order
-    createHorizonsSpreadSheetLayer('Artemis Time', `${header}\r\n${data}`, 'Sky')
+    createHorizonsSpreadSheetLayer('Artemis', `${header}\r\n${data}`, 'Sky')
       .then(layer => {
-        layer.set_markerScale(MarkerScales.world);
+        layer.set_markerScale(MarkerScales.screen);
         layer.set_plotType(PlotTypes.gaussian);
-        layer.set_scaleFactor(0.0012);
-        layer.set_color(Color.fromHex("#00ffff")); // artemis
+        layer.set_scaleFactor(20);
+        layer.set_color(Color.fromHex("#ffffff")); // artemis
         layer.set_showFarSide(true);
         layer.set_opacity(100);
         layers.value.push(layer);
@@ -496,19 +499,20 @@ onMounted(() => {
   
     // @ts-expect-error this does exist
     WWTControl.singleton.shallowLayerTest = function(layer) {
-      const table = layer.get__table();
-      const rows = table.rows;
-      const count = rows.length;
-      const center = Math.floor(count / 2);
-      const centerRow = rows[center];
-      const x = Number(centerRow[layer.get_xAxisColumn()]);
-      const y = Number(centerRow[layer.get_yAxisColumn()]);
-      const z = Number(centerRow[layer.get_zAxisColumn()]);
-      // @ts-expect-error this does exist
-      const depth = WWTControl.singleton.getDepth(x, y, z);
-      // @ts-expect-error this does exist
-      const moonDepth = WWTControl.singleton.getDepth(0, 0, 0);
-      return depth <= (moonDepth + 0.0000116 / 6); // magic number minor improvement to front side depth test
+      return true;
+      // const table = layer.get__table();
+      // const rows = table.rows;
+      // const count = rows.length;
+      // const center = Math.floor(count / 2);
+      // const centerRow = rows[center];
+      // const x = Number(centerRow[layer.get_xAxisColumn()]);
+      // const y = Number(centerRow[layer.get_yAxisColumn()]);
+      // const z = Number(centerRow[layer.get_zAxisColumn()]);
+      // // @ts-expect-error this does exist
+      // const depth = WWTControl.singleton.getDepth(x, y, z);
+      // // @ts-expect-error this does exist
+      // const moonDepth = WWTControl.singleton.getDepth(0, 0, 0);
+      // return depth <= (moonDepth + 0.0000116 / 6); // magic number minor improvement to front side depth test
     }.bind(this);
 
     

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -299,17 +299,8 @@ const EARTH_VIEW: CameraView = {
   angleDeg: 0,
   time: 1775474823266
 };
-// const HOME_VIEW: CameraView = {
-//   // lng: 169.906038,
-//   lng: 168.007573,
-//   // lat: 1.323000,
-//   lat: 3.591000,
-//   // zoomDeg: 0.000163,
-//   zoomDeg: 0.000157,
-//   rotationDeg: 0,
-//   angleDeg: 0,
-//   time: HOME_TIME.getTime()
-// };
+
+const { copyViewUrl, copySuccess } = useCameraUrl(INITIAL_VIEW);
 
 
 const currentTime = ref(INITIAL_TIME.value);
@@ -337,9 +328,7 @@ function doWWTHacks() {
 }
 
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-let copyViewUrl: () => Promise<void> = async () => {};
-const copySuccess = ref(false);
+
 
 
 const layers = ref<SpreadSheetLayer[]>([]);
@@ -532,7 +521,7 @@ onMounted(() => {
     createArtemisLayers(trackingCenter.value);
 
 
-    ({ copyViewUrl } = useCameraUrl(INITIAL_VIEW, copySuccess));
+    
     positionSet.value = true;
     layersLoaded.value = true;
   });

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -395,48 +395,35 @@ function createHorizonsSpreadSheetLayer(name: string, dataCsv: string, reference
 
 function createArtemisLayers(trackedObject: SolarSystemObjects) {
   const vec =   parseHorizonsVectorsForWwt(horizonsData, SolarSystemObjects.earth, trackedObject);
-  const items = vec.split("\r\n");
-  const header = items.shift();
-  let bounds: [number, number][] = [];
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const N = 10;
-  const centerStart = 1300;
-  const centerEnd = 1500;
-  const end = items.length;
-  for (let i = centerStart; i < centerEnd; i += N) {
-    bounds.push([i, i + N]);
-  }
-  bounds = [[0, centerStart], ...bounds, [centerEnd, end]];
-  bounds.forEach((bds) => {
-    const data = items.slice(...bds).join("\r\n");
-
-    // REMOVE: temp for degugging layer order
-    createHorizonsSpreadSheetLayer('Artemis', `${header}\r\n${data}`, 'Sky')
-      .then(layer => {
-        layer.set_markerScale(MarkerScales.screen);
-        layer.set_plotType(PlotTypes.gaussian);
-        layer.set_scaleFactor(20);
-        layer.set_color(Color.fromHex("#ffffff")); // artemis
-        layer.set_showFarSide(true);
-        layer.set_opacity(100);
-        layers.value.push(layer);
-      });
+  
+  // REMOVE: temp for degugging layer order
+  createHorizonsSpreadSheetLayer('Artemis', vec, 'Sky')
+    .then(layer => {
+      layer.set_markerScale(MarkerScales.screen);
+      layer.set_plotType(PlotTypes.gaussian);
+      layer.set_scaleFactor(20);
+      layer.set_color(Color.fromHex("#ffffff")); // artemis
+      layer.set_showFarSide(true);
+      layer.set_opacity(100);
+      layers.value.push(layer);
+    });
     
-    createHorizonsSpreadSheetLayer('Artemis Time', `${header}\r\n${data}`, 'Sky')
-      .then(layer => {
-        layer.set_markerScale(MarkerScales.screen);
-        layer.set_plotType(PlotTypes.gaussian);
-        layer.set_scaleFactor(25);
-        layer.set_color(Color.fromHex("#df1c23")); // artemis
-        layer.set_showFarSide(true);
-        layer.set_opacity(100);
-        layer.set_startDateColumn(1);
-        layer.set_endDateColumn(1);
-        layer.set_decay(4.9 / (60 * 24));
-        layer.set_timeSeries(true);
-        layers.value.push(layer);
-      });
-  });
+  
+  createHorizonsSpreadSheetLayer('Artemis Time', vec, 'Sky')
+    .then(layer => {
+      layer.set_markerScale(MarkerScales.screen);
+      layer.set_plotType(PlotTypes.gaussian);
+      layer.set_scaleFactor(40);
+      layer.set_color(Color.fromHex("#df1c23")); // artemis
+      layer.set_showFarSide(true);
+      layer.set_opacity(100);
+      layer.set_startDateColumn(1);
+      layer.set_endDateColumn(1);
+      layer.set_decay(4.9 / (60 * 24));
+      layer.set_timeSeries(true);
+      layers.value.push(layer);
+    });
+
 }
 
 function removeArtemisLayers() {

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -63,7 +63,7 @@
               @activate="() => showInfoSheet = !showInfoSheet"
             >
             </icon-button>
-            <button 
+            <button
               class="artemis-btn zoom-label"
               @click="zoomIn"
               @keyup.enter="zoomIn"
@@ -80,7 +80,7 @@
               :value="zoomSliderValue"
               @input="onZoomSlider"
             />
-            <button 
+            <button
               class="artemis-btn zoom-label"
               @click="zoomOut"
               @keyup.enter="zoomOut"
@@ -199,7 +199,7 @@
         :text-color="accentColor"
       />
     </div>
-    <WebGlTest 
+    <WebGlTest
       @webgl2-disabled="webglDisabled = true"
     />
   </v-app>
@@ -210,7 +210,7 @@ import { ref, computed, onMounted, watch } from "vue";
 import { engineStore } from "@wwtelescope/engine-pinia";
 import { supportsTouchscreen, useWWTKeyboardControls, CreditLogos, IconButton, useFullscreen } from "@cosmicds/vue-toolkit";
 import { useDisplay } from "vuetify";
-import { Color, SpreadSheetLayer, OrbitLineList, LayerManager, WWTControl, Vector3d } from "@wwtelescope/engine";
+import { BasePlanets, Color, SpreadSheetLayer, OrbitLineList, LayerManager, WWTControl, Vector3d } from "@wwtelescope/engine";
 import { MarkerScales, PlotTypes, SolarSystemObjects } from "@wwtelescope/engine-types";
 
 /* Component imports */
@@ -226,19 +226,20 @@ const webglDisabled = ref(false);
 
 /* local imports */
 import { useCameraUrl } from "./composables/useCameraUrl";
-import { 
-  moveViewCamera, 
-  layerManagerDraw, 
+import {
+  moveViewCamera,
+  layerManagerDraw,
   getCoordinatesForScreenPoint,
-  getScreenPointForCoordinates, 
-  transformPickPointToWorldSpace, 
-  transformWorldPointToPickSpace, 
+  getScreenPointForCoordinates,
+  transformPickPointToWorldSpace,
+  transformWorldPointToPickSpace,
   renderOneFrame,
-  makeFrustum, 
+  makeFrustum,
   addToWWTRenderLoop,
   removeFromWWTRenderLoop,
   spreadSheetLayerDraw,
-  type CameraView 
+  drawPointPlanet,
+  type CameraView
 } from "./wwt-hacks";
 import { clampedTime } from "./utils";
 
@@ -333,6 +334,8 @@ function doWWTHacks() {
   LayerManager._draw = layerManagerDraw;
   // @ts-expect-error this does exist
   SpreadSheetLayer.prototype.draw = spreadSheetLayerDraw;
+
+  BasePlanets.drawPointPlanet = drawPointPlanet;
 }
 
 
@@ -372,8 +375,8 @@ function createArtemisOrbitLineList(trackedObject: SolarSystemObjects) {
   });
   for (let i = 1; i < points.length; i++) {
     lineList.addLine(
-      points[i - 1], 
-      points[i], 
+      points[i - 1],
+      points[i],
       color,
       color,
     );
@@ -392,7 +395,7 @@ function createHorizonsSpreadSheetLayer(name: string, dataCsv: string, reference
 
 function createArtemisLayers(trackedObject: SolarSystemObjects) {
   const vec =   parseHorizonsVectorsForWwt(horizonsData, SolarSystemObjects.earth, trackedObject);
-  
+
   // REMOVE: temp for degugging layer order
   // createHorizonsSpreadSheetLayer('Artemis', vec, 'Sky')
   //   .then(layer => {
@@ -404,8 +407,8 @@ function createArtemisLayers(trackedObject: SolarSystemObjects) {
   //     layer.set_opacity(100);
   //     layers.value.push(layer);
   //   });
-    
-  
+
+
   createHorizonsSpreadSheetLayer('Artemis Time', vec, 'Sky')
     .then(layer => {
       layer.set_markerScale(MarkerScales.screen);
@@ -455,7 +458,7 @@ function removeArtemisOrbit() {
 }
 
 onMounted(() => {
-  
+
   if (webglDisabled.value) {
     showSplashScreen.value = false;
     // eslint-disable-next-lint @typescript-eslint/ban-ts-comment
@@ -480,7 +483,6 @@ onMounted(() => {
     store.applySetting(["solarSystemStars", showSkyBackground.value]);
     store.setTrackedObject(trackingCenter.value);
 
-    
     createArtemisOrbit();
     createArtemisLayers(trackingCenter.value);
 

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -229,7 +229,6 @@ import { useCameraUrl } from "./composables/useCameraUrl";
 import { 
   moveViewCamera, 
   layerManagerDraw, 
-  getDepth, 
   getCoordinatesForScreenPoint,
   getScreenPointForCoordinates, 
   transformPickPointToWorldSpace, 
@@ -328,8 +327,6 @@ function doWWTHacks() {
   // @ts-expect-error this does exist
   WWTControl.singleton.transformPickPointToWorldSpace = transformPickPointToWorldSpace.bind(WWTControl.singleton);
   WWTControl.singleton.renderOneFrame = renderOneFrame.bind(WWTControl.singleton);
-  // @ts-expect-error this does exist
-  WWTControl.singleton.getDepth = getDepth.bind(WWTControl.singleton);
   // @ts-expect-error this does exist
   WWTControl.singleton.renderContext.makeFrustum = makeFrustum.bind(WWTControl.singleton.renderContext);
   // @ts-expect-error this does exist
@@ -482,12 +479,6 @@ onMounted(() => {
     store.applySetting(["solarSystemMilkyWay", showSkyBackground.value]);
     store.applySetting(["solarSystemStars", showSkyBackground.value]);
     store.setTrackedObject(trackingCenter.value);
-    
-  
-    // @ts-expect-error this does exist
-    WWTControl.singleton.shallowLayerTest = function(_layer) {
-      return true;
-    }.bind(this);
 
     
     createArtemisOrbit();

--- a/src/WwtPlayground.vue
+++ b/src/WwtPlayground.vue
@@ -211,7 +211,7 @@ import { engineStore } from "@wwtelescope/engine-pinia";
 import { supportsTouchscreen, useWWTKeyboardControls, CreditLogos, IconButton, useFullscreen } from "@cosmicds/vue-toolkit";
 import { useDisplay } from "vuetify";
 import { Color, SpreadSheetLayer, OrbitLineList, LayerManager, WWTControl, Vector3d } from "@wwtelescope/engine";
-import { CoordinatesType, MarkerScales, PlotTypes, SolarSystemObjects, AltUnits } from "@wwtelescope/engine-types";
+import { MarkerScales, PlotTypes, SolarSystemObjects } from "@wwtelescope/engine-types";
 
 /* Component imports */
 import ArtemisTimeControl from "./components/ArtemisTimeControl.vue";

--- a/src/components/ArtemisTimeControl.vue
+++ b/src/components/ArtemisTimeControl.vue
@@ -62,13 +62,16 @@ import { SpaceTimeController } from "@wwtelescope/engine";
 interface Props {
   canCreate: boolean;
   initialTime: Date;
+  startTime: Date;
+  endTime: Date;
+  step: number;
 }
 
 const props = defineProps<Props>();
   
 const currentTime = defineModel<Date>('time', {default: new Date()});
 SpaceTimeController.set_now(props.initialTime);
-console.log(currentTime.value, props.initialTime);
+
 watch(currentTime, (date) => {
   SpaceTimeController.set_now(date);
 });
@@ -92,10 +95,10 @@ function goToNow() {
 
 
 // 2026-Apr-02 01:59:00.0000
-const MISSION_START = new Date("2026-04-02T01:59:00Z");
+const MISSION_START = props.startTime ?? new Date("2026-04-02T01:59:00Z");
 // 2026-Apr-10 23:54:00.0000
-const MISSION_END   = new Date("2026-04-10T23:54:00Z");
-const STEP_MS       = 5 * 60 * 1000;
+const MISSION_END   = props.endTime ?? new Date("2026-04-10T23:54:00Z");
+const STEP_MS       = props.step ?? 5 * 60 * 1000;
 
 const INITIAL_TIME = props.initialTime; //new Date("2026-04-06T22:32:00Z");
 

--- a/src/composables/useCameraUrl.ts
+++ b/src/composables/useCameraUrl.ts
@@ -2,9 +2,9 @@ import { engineStore } from "@wwtelescope/engine-pinia";
 import { WWTControl } from "@wwtelescope/engine";
 import { R2D } from "@wwtelescope/astro";
 import { moveViewCamera, type CameraView } from "../wwt-hacks";
-import { Ref, watch } from 'vue';
+import { watch, onMounted, ref } from 'vue';
 
-export function useCameraUrl(fallback: CameraView, successWatch: Ref<boolean>) {
+export function useCameraUrl(fallback: CameraView) {
   const store = engineStore();
 
   const lng         = () => ((360 - store.raRad * R2D) % 360);
@@ -13,6 +13,7 @@ export function useCameraUrl(fallback: CameraView, successWatch: Ref<boolean>) {
   const rotationDeg = () => store.rollRad * R2D;
   const angleDeg    = () => WWTControl.singleton.renderContext.viewCamera.angle;
   const time        = () => store.currentTime.getTime();
+  const successWatch = ref(false);
 
   function readUrl(): CameraView {
     const p = new URLSearchParams(window.location.search);
@@ -50,7 +51,11 @@ export function useCameraUrl(fallback: CameraView, successWatch: Ref<boolean>) {
     }
   });
   // Apply initial view from URL (or fallback) once.
-  moveViewCamera(readUrl(), true);
+  onMounted(() => {
+    store.waitForReady().then(() => {
+      moveViewCamera(readUrl(), true);
+    });
+  });
 
-  return { copyViewUrl };
+  return { copyViewUrl, copySuccess: successWatch };
 }

--- a/src/composables/useCameraUrl.ts
+++ b/src/composables/useCameraUrl.ts
@@ -3,6 +3,7 @@ import { WWTControl } from "@wwtelescope/engine";
 import { R2D } from "@wwtelescope/astro";
 import { moveViewCamera, type CameraView } from "../wwt-hacks";
 import { watch, onMounted, ref } from 'vue';
+import { usePromisedValue } from "./usePromisedValue";
 
 export function useCameraUrl(fallback: CameraView) {
   const store = engineStore();
@@ -14,6 +15,8 @@ export function useCameraUrl(fallback: CameraView) {
   const angleDeg    = () => WWTControl.singleton.renderContext.viewCamera.angle;
   const time        = () => store.currentTime.getTime();
   const successWatch = ref(false);
+  
+  const { promise: afterInitialized, value: moveInitialized } = usePromisedValue();
 
   function readUrl(): CameraView {
     const p = new URLSearchParams(window.location.search);
@@ -54,8 +57,9 @@ export function useCameraUrl(fallback: CameraView) {
   onMounted(() => {
     store.waitForReady().then(() => {
       moveViewCamera(readUrl(), true);
+      moveInitialized.value = true;
     });
   });
 
-  return { copyViewUrl, copySuccess: successWatch };
+  return { copyViewUrl, copySuccess: successWatch, afterInitialized };
 }

--- a/src/composables/usePromisedValue.ts
+++ b/src/composables/usePromisedValue.ts
@@ -1,0 +1,26 @@
+import { ref, watch } from "vue";
+
+/** 
+ * Allows you to ref/promise pair, that resolves the promise when the ref is set to a non-null value. 
+ * Useful for waiting for something to be initialized in a composable, without having to expose the ref itself. 
+ */
+export function usePromisedValue() {
+  const value = ref(false);
+  
+  let resolver: ((value: boolean) => void) | null = null;
+  let rejector: ((error: Error) => void) | null = null;
+  const promise = new Promise<boolean>((resolve, reject) => {
+    resolver = resolve;
+    rejector = reject;
+  });
+
+  watch(value, (newValue) => {
+    if (newValue !== null && resolver) {
+      resolver(newValue);
+    } else if (newValue === null && rejector) {
+      rejector(new Error("Value was reset to null"));
+    }
+  }, { immediate: true });
+
+  return { value: value, promise };
+}

--- a/src/composables/useScaledZoom.ts
+++ b/src/composables/useScaledZoom.ts
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { computed } from "vue";
+import { WWTControl } from "@wwtelescope/engine";
+import { engineStore } from "@wwtelescope/engine-pinia";
+
+export function useScaledZoom() {
+  
+  const store = engineStore();
+    
+  const ZOOM_MIN   = 0.00006;
+  const ZOOM_MAX   = 240;
+  const LOG_MIN    = Math.log(ZOOM_MIN);
+  const LOG_MAX    = Math.log(ZOOM_MAX);
+  // Power < 1 stretches the small-fov (zoomed-in) end of the slider.
+  const ZOOM_POWER = 3.5;
+
+  // Map linear slider position [0,1] → stretched slider position [0,1].
+  const stretchSlider   = (t: number) => Math.pow(t, ZOOM_POWER);
+  // Inverse: stretched slider position → linear slider position.
+  const unstretchSlider = (t: number) => Math.pow(t, 1 / ZOOM_POWER);
+
+  function fovToSlider(fov: number): number {
+    const linear = (Math.log(fov) - LOG_MIN) / (LOG_MAX - LOG_MIN);
+    return unstretchSlider(linear);
+  }
+  function sliderToFov(t: number): number {
+    return Math.exp(LOG_MIN + stretchSlider(t) * (LOG_MAX - LOG_MIN));
+  }
+  
+  const zoomSliderValue = computed(() => fovToSlider(store.zoomDeg));
+
+  function onZoomSlider(e: Event) {
+    const fov = sliderToFov(+(e.target as HTMLInputElement).value);
+    const rc = WWTControl.singleton.renderContext;
+    rc.targetCamera.zoom = fov;
+    rc.viewCamera.zoom   = fov;
+    WWTControl.singleton.renderOneFrame();
+  }
+  
+  function zoomIn() {
+    const newZoom = store.zoomDeg / 1.25;
+    const clampedZoom = Math.max(newZoom, ZOOM_MIN);
+    const rc = WWTControl.singleton.renderContext;
+    rc.targetCamera.zoom = clampedZoom;
+    rc.viewCamera.zoom   = clampedZoom;
+    WWTControl.singleton.renderOneFrame();
+  }
+
+  function zoomOut() {
+    const newZoom = store.zoomDeg * 1.25;
+    const clampedZoom = Math.min(newZoom, ZOOM_MAX);
+    const rc = WWTControl.singleton.renderContext;
+    rc.targetCamera.zoom = clampedZoom;
+    rc.viewCamera.zoom   = clampedZoom;
+    WWTControl.singleton.renderOneFrame();
+  }
+
+  
+  return {
+    zoomSliderValue,
+    onZoomSlider,
+    ZOOM_MAX,
+    ZOOM_MIN,
+    zoomIn,
+    zoomOut,
+  };
+}

--- a/src/horizons.ts
+++ b/src/horizons.ts
@@ -64,3 +64,27 @@ export function parseHorizonsVectorsForWwt(rawText: string, horizonsCenter = Sol
   );
   return ["jdtdb,date,x,y,z,end", ...rows].join("\r\n");
 }
+
+
+/**
+ * get the start and end time of the horizons data
+ * horizonsCsvString is the output of parseHorizonsVectorsForWwt
+ */
+export function getHorizonsStartEndTimes(horizonsCsvString: string): { start: Date, end: Date, deltaT: number } {
+  let lines = horizonsCsvString.split(/\r?\n/);
+  if (!lines[0].startsWith("jdtdb")) {
+    lines = parseHorizonsVectorsForWwt(horizonsCsvString).split(/\r?\n/);
+  }
+
+  const firstLine = lines[1];
+  const secondLine = lines[2];
+  const lastLine = lines[lines.length - 1];
+  
+  // the strings are ISO strings with 'Z' at the end, so this will be parsed as UTC time
+  const startDate = new Date(firstLine.split(",")[1]); 
+  const endDate = new Date(lastLine.split(",")[1]);
+  
+  const stepMs = new Date(secondLine.split(",")[1]).getTime() - startDate.getTime();
+
+  return { start: startDate, end: endDate, deltaT: stepMs };
+}

--- a/src/horizons.ts
+++ b/src/horizons.ts
@@ -1,5 +1,5 @@
-import { SpaceTimeController, Planets, Vector3d } from "@wwtelescope/engine";
-import { SolarSystemObjects } from "@wwtelescope/engine-types";
+import { SpaceTimeController, Planets, Vector3d, type SpreadSheetLayer } from "@wwtelescope/engine";
+import { SolarSystemObjects, AltUnits, CoordinatesType } from "@wwtelescope/engine-types";
 const FIVE_MINUTES = 5 * 60 * 1000;
 const D2S = 24 * 60 * 60;
 
@@ -87,4 +87,22 @@ export function getHorizonsStartEndTimes(horizonsCsvString: string): { start: Da
   const stepMs = new Date(secondLine.split(",")[1]).getTime() - startDate.getTime();
 
   return { start: startDate, end: endDate, deltaT: stepMs };
+}
+
+
+/**
+ * Setup the spreadsheet layer columns and
+ * coordinates after createTableLayer creates the layer
+ * then style the output.
+ */
+export function setupHorizonsSpreadSheetLayer(layer: SpreadSheetLayer) {
+  layer.set_xAxisColumn(2);
+  layer.set_yAxisColumn(3);
+  layer.set_zAxisColumn(4);
+  layer.set_coordinatesType(CoordinatesType.rectangular);
+  layer.set_astronomical(true);
+  layer.set_cartesianScale(AltUnits.astronomicalUnits);
+  layer.set_altUnit(AltUnits.astronomicalUnits);
+  layer.set_showFarSide(true);
+  return layer;
 }

--- a/src/shims-wwt.d.ts
+++ b/src/shims-wwt.d.ts
@@ -8,6 +8,13 @@ import { SolarSystemObjects } from "@wwtelescope/engine-types";
 
 declare module "@wwtelescope/engine" {
 
+  export class BasePlanets {
+    drawPointPlanet(renderContext: RenderContext, location: Vector3d, size: number, color: Color, zOrder: number);
+  }
+
+  export class Dates {};
+  export class PointList {};
+
   // this seems to be the write way to extend the class. do a normal import
   // and ts will merge? this interface. idk really.
   interface RenderContext  {
@@ -41,7 +48,7 @@ declare module "@wwtelescope/engine" {
     raDecTo3d(ra: number, dec: number): Vector3d;
     horizonToEquitorial(altAz: Coordinates, location: Coordinates, utc: Date): Coordinates;
   }
-  
+
   namespace Vector3d {
     function addVectors(left: Vector3d, right: Vector3d): Vector3d;
     function negate(left: Vector3d, right: Vector3d): Vector3d;
@@ -100,11 +107,11 @@ declare module "@wwtelescope/engine" {
     static drawPlanets3D(renderContext: renderContext, opacity: number, centerPoint: Vector3d);
   }
 
-  
+
   namespace Planets {
     function getPlanet3dLocationJD(target: SolarSystemObjects, jNow: number): Vector3d;
   }
-  
+
     // this on the other hand is not exported at all, so we create the class declaration here
   export class OrbitLineList {
     addLine(pt1: Vector3d, pt2: Vector3d, color1: Color, color2: Color): void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+export function clampedTime(time: Date, min: Date, max: Date): Date {
+  if (time < min) {
+    return min;
+  } else if (time > max) {
+    return max;
+  } else {
+    return time;
+  }
+}

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -415,7 +415,8 @@ export function renderOneFrame() {
         matLocal._multiply(Matrix3d.translation(vt));
         this.renderContext.set_world(matLocal);
         this.renderContext.makeFrustum();
-
+        
+        
         LayerManager._draw(this.renderContext, 1, true, 'Sky', true, false, (layer) => this.shallowLayerTest ? !this.shallowLayerTest(layer) : false);
         this.renderContext.set_world(matOld);
         this.renderContext.makeFrustum();
@@ -752,6 +753,11 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         this.triangleList.draw(renderContext, opacity * this.get_opacity(), 1);
     }
     if (this.pointList != null) {
+        // so this ends up causing gl.enable(gl.DEPTH_TEST) 
+        // so that the test is run. if depth mask is true then buffers get written
+        // that is, if it is in front it get's written
+        // https://learnopengl.com/Advanced-OpenGL/Depth-testing
+        // https://gamedev.net/forums/topic/404620-clarifying-glenablegl_depth_test-and-gldepthmask/#post-3688636
         this.pointList.depthBuffered = true;
         this.pointList.showFarSide = this.get_showFarSide();
         this.pointList.decay = (this.timeSeries) ? this.decay : 0;
@@ -760,7 +766,12 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         this.pointList.jNow = jNow;
         this.pointList.scale = (this._markerScale$1 === 1) ? adjustedScale : -adjustedScale;
         // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/depthMask
-        renderContext.gl.depthMask(false) // we're depth buffered, but no writing to it. works, buuuuuuut??????
+        // so we are running the depth test, but with this, then we are not
+        // updating the depth bugger.
+        // *** so then in a pixel - every point in that pixel get's drawn at the same depth, 
+        // **** according to where this layer is in the order?
+        // with shallowLayerTest always returning true, this renders properly
+        renderContext.gl.depthMask(false)
         switch (this._plotType$1) {
             case 0:
                 this.pointList.draw(renderContext, opacity * this.get_opacity(), false);

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -257,25 +257,7 @@ export function getScreenPointForCoordinates(x, y, z=0) {
     return result;
 }
 
-// export function getDepth(x, y, z) {
-//   const pt = this.getScreenPointForCoordinates(x, y, z);
-//   const near = -1;
-//   const far = 1;
-//   const nearPt = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, true, near);
-//   const farPt = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, true, far);
-//   // In principle, should give the same value for y and z
-//   return (x - nearPt.x) / (farPt.x - nearPt.x);
-// }
 
-export function getDepth(x, y, z) {
-    const worldPoint = Vector3d.create(x, y, z);
-    var m = Matrix3d.multiplyMatrix(this.renderContext.get_world(), this.renderContext.get_view());
-    m = Matrix3d.multiplyMatrix(m, this.renderContext.get_projection());
-
-    var vz = (worldPoint.x * m.get_m13() + worldPoint.y * m.get_m23() + worldPoint.z * m.get_m33() + m.get_m43());
-
-    return vz;
-}
 
 export function renderOneFrame() {
     if (this.renderContext.get_backgroundImageset() != null) {
@@ -417,7 +399,7 @@ export function renderOneFrame() {
         this.renderContext.makeFrustum();
         
         
-        LayerManager._draw(this.renderContext, 1, true, 'Sky', true, false, (layer) => this.shallowLayerTest ? !this.shallowLayerTest(layer) : false);
+
         this.renderContext.set_world(matOld);
         this.renderContext.makeFrustum();
 
@@ -431,11 +413,11 @@ export function renderOneFrame() {
             }
         }
 
-        if (this.shallowLayerTest) {
-          LayerManager._draw(this.renderContext, 1, true, 'Sky', true, false, (layer) => this.shallowLayerTest(layer));
-          this.renderContext.set_world(matOld);
-          this.renderContext.makeFrustum();
-        }
+
+        LayerManager._draw(this.renderContext, 1, true, 'Sky', true, false, null);
+        this.renderContext.set_world(matOld);
+        this.renderContext.makeFrustum();
+
 
     } else {
         // RenderType is not SolarSystem
@@ -621,43 +603,7 @@ export function makeFrustum() {
     this._setMatrixes();
 }
 
-// TODO: This doesn't work
-// export function getTableDataInView() {
-//     var data = '';
-//     var first = true;
-//     for (const col of this.get_header()) {
-//         if (!first) {
-//             data += '\t';
-//         }
-//         else {
-//             first = false;
-//         }
-//         data += col;
-//     }
-//     data += '\r\n';
-//     const planetMode = WWTControl.singleton.renderContext.get_backgroundImageset().get_dataSetType() < 2;
-//     for (const row of this.get__table().rows) {
-//         var x = parseFloat(row[this.get_xAxisColumn()]);
-//         var y = parseFloat(row[this.get_yAxisColumn()]);
-//         var z = parseFloat(row[this.get_zAxisColumn()]);
-//         var position = Vector3d.create(x, y, z);
-//         if (!this._isPointInFrustum$1(position, WWTControl.singleton.renderContext.get_frustum())) {
-//             continue;
-//         }
-//         first = true;
-//         for (const col of row) {
-//             if (!first) {
-//                 data += '\t';
-//             }
-//             else {
-//                 first = false;
-//             }
-//             data += col;
-//         }
-//         data += '\r\n';
-//     }
-//     return data;
-// }
+
 
 export function layerManagerDraw(renderContext, opacity, astronomical, referenceFrame, nested, cosmos, filter=null) {
     if (!(referenceFrame in LayerManager.get_allMaps())) {
@@ -704,7 +650,7 @@ export function layerManagerDraw(renderContext, opacity, astronomical, reference
                         if (SpaceTimeController.get_jNow() > layerEnd) {
                             fadeOpacity = ((fadeOut - SpaceTimeController.get_jNow()) / (layer.get_fadeSpan() / 864000000));
                         }
-                        if (filter && filter(layer)) {
+                        if (!filter || filter(layer)) {
                             layer.set_astronomical(astronomical);
                             layer.draw(renderContext, opacity * fadeOpacity, cosmos);
                         }
@@ -770,7 +716,7 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         // updating the depth bugger.
         // *** so then in a pixel - every point in that pixel get's drawn at the same depth, 
         // **** according to where this layer is in the order?
-        // with shallowLayerTest always returning true, this renders properly
+
         // const ogDepthMaskValue = renderContext.gl.getParameter(renderContext.gl.DEPTH_WRITEMASK)
         renderContext.gl.depthMask(false)
         switch (this._plotType$1) {

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -752,7 +752,7 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         this.triangleList.draw(renderContext, opacity * this.get_opacity(), 1);
     }
     if (this.pointList != null) {
-        this.pointList.depthBuffered = false;
+        this.pointList.depthBuffered = true;
         this.pointList.showFarSide = this.get_showFarSide();
         this.pointList.decay = (this.timeSeries) ? this.decay : 0;
         this.pointList.sky = this.get_astronomical();

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -4,6 +4,7 @@
 import {
   Annotation,
   Constellations,
+  Dates,
   // @ts-expect-error Grid does exist
   Grids,
   ImageSetLayer,
@@ -12,6 +13,7 @@ import {
   Matrix3d,
   Planets,
   Planets3d,
+  PointList,
   RenderTriangle,
   Settings,
   SpaceTimeController,
@@ -397,11 +399,6 @@ export function renderOneFrame() {
         matLocal._multiply(Matrix3d.translation(vt));
         this.renderContext.set_world(matLocal);
         this.renderContext.makeFrustum();
-        
-        
-
-        this.renderContext.set_world(matOld);
-        this.renderContext.makeFrustum();
 
         if (this.renderContext.get_solarSystemCameraDistance() < 15000) {
             this.renderContext.setupMatricesSolarSystem(false);
@@ -699,7 +696,7 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         this.triangleList.draw(renderContext, opacity * this.get_opacity(), 1);
     }
     if (this.pointList != null) {
-        // so this ends up causing gl.enable(gl.DEPTH_TEST) 
+        // so this ends up causing gl.enable(gl.DEPTH_TEST)
         // so that the test is run. if depth mask is true then buffers get written
         // that is, if it is in front it get's written
         // https://learnopengl.com/Advanced-OpenGL/Depth-testing
@@ -714,7 +711,7 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/depthMask
         // so we are running the depth test, but with this, then we are not
         // updating the depth bugger.
-        // *** so then in a pixel - every point in that pixel get's drawn at the same depth, 
+        // *** so then in a pixel - every point in that pixel get's drawn at the same depth,
         // **** according to where this layer is in the order?
 
         // const ogDepthMaskValue = renderContext.gl.getParameter(renderContext.gl.DEPTH_WRITEMASK)
@@ -741,7 +738,7 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         }
         // renderContext.gl.depthMask(ogDepthMaskValue);
         renderContext.gl.depthMask(true); // checked. ogDepthMaskValue is true
-        
+
     }
     if (this.lineList != null) {
         this.lineList.sky = this.get_astronomical();
@@ -759,4 +756,42 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         this.lineList2d.drawLines(renderContext, opacity * this.get_opacity());
     }
     return true;
+}
+
+export function drawPointPlanet(renderContext, location, size, color, zOrder) {
+    var center = location;
+    var rad = size / 2;
+    if (renderContext.gl != null) {
+        var ppList = new PointList(renderContext);
+        ppList.minSize = 20;
+        ppList.addPoint(location.copy(), color._clone(), new Dates(0, 1), size / 100);
+        ppList.depthBuffered = true;
+        renderContext.gl.depthMask(false);
+        ppList.draw(renderContext, 1, false);
+        renderContext.gl.depthMask(true);
+    }
+    else {
+        var screenSpacePnt = renderContext.WVP.transform(center);
+        if (screenSpacePnt.z < 0) {
+            return;
+        }
+        if (!zOrder) {
+            if (Vector3d.dot(renderContext.get_viewPoint(), center) < 0.55) {
+                return;
+            }
+        }
+        var ctx = renderContext.device;
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(screenSpacePnt.x, screenSpacePnt.y, rad, 0, Math.PI * 2, true);
+        ctx.lineWidth = 1;
+        ctx.fillStyle = color.toString();
+        if (true) {
+            ctx.fill();
+        }
+        ctx.globalAlpha = 1;
+        ctx.strokeStyle = color.toString();
+        ctx.stroke();
+        ctx.restore();
+    }
 }

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -16,6 +16,7 @@ import {
   Settings,
   SpaceTimeController,
   SpreadSheetLayer,
+  PushPin,
   Tile,
   TileCache,
   TourPlayer,
@@ -715,3 +716,84 @@ export function layerManagerDraw(renderContext, opacity, astronomical, reference
     renderContext.set_world(matOld);
     renderContext.set_worldBaseNonRotating(matOldNonRotating);
 };
+
+
+
+export function spreadSheetLayerDraw(renderContext, opacity, flat) {
+    var device = renderContext;
+    if (this.version !== this.lastVersion) {
+        this.cleanUp();
+    }
+    this.lastVersion = this.version;
+    if (this.bufferIsFlat !== flat) {
+        this.cleanUp();
+        this.bufferIsFlat = flat;
+    }
+    if (this.dirty) {
+        this.prepVertexBuffer(device, opacity);
+    }
+    var jNow = SpaceTimeController.get_jNow() - SpaceTimeController.utcToJulian(this.baseDate);
+    var adjustedScale = this.scaleFactor * 3;
+    if (flat && this.astronomical && (this._markerScale$1 === 1)) {
+        adjustedScale = (this.scaleFactor / (renderContext.viewCamera.zoom / 360));
+    }
+    if (this.triangleList2d != null) {
+        this.triangleList2d.decay = this.decay;
+        this.triangleList2d.sky = this.get_astronomical();
+        this.triangleList2d.timeSeries = this.timeSeries;
+        this.triangleList2d.jNow = jNow;
+        this.triangleList2d.draw(renderContext, opacity * this.get_opacity(), 1);
+    }
+    if (this.triangleList != null) {
+        this.triangleList.decay = this.decay;
+        this.triangleList.sky = this.get_astronomical();
+        this.triangleList.timeSeries = this.timeSeries;
+        this.triangleList.jNow = jNow;
+        this.triangleList.draw(renderContext, opacity * this.get_opacity(), 1);
+    }
+    if (this.pointList != null) {
+        this.pointList.depthBuffered = false;
+        this.pointList.showFarSide = this.get_showFarSide();
+        this.pointList.decay = (this.timeSeries) ? this.decay : 0;
+        this.pointList.sky = this.get_astronomical();
+        this.pointList.timeSeries = this.timeSeries;
+        this.pointList.jNow = jNow;
+        this.pointList.scale = (this._markerScale$1 === 1) ? adjustedScale : -adjustedScale;
+        switch (this._plotType$1) {
+            case 0:
+                this.pointList.draw(renderContext, opacity * this.get_opacity(), false);
+                break;
+            case 2:
+                this.pointList.drawTextured(renderContext, SpreadSheetLayer.get__circleTexture$1().texture2d, opacity * this.get_opacity());
+                break;
+            case 1:
+                this.pointList.drawTextured(renderContext, PushPin.getPushPinTexture(19), opacity * this.get_opacity());
+                break;
+            case 3:
+                this.pointList.drawTextured(renderContext, PushPin.getPushPinTexture(35), opacity * this.get_opacity());
+                break;
+            case 5:
+            case 4:
+                this.pointList.drawTextured(renderContext, PushPin.getPushPinTexture(this._markerIndex$1), opacity * this.get_opacity());
+                break;
+            default:
+                break;
+        }
+    }
+    if (this.lineList != null) {
+        this.lineList.sky = this.get_astronomical();
+        this.lineList.decay = this.decay;
+        this.lineList.timeSeries = this.timeSeries;
+        this.lineList.jNow = jNow;
+        this.lineList.drawLines(renderContext, opacity * this.get_opacity());
+    }
+    if (this.lineList2d != null) {
+        this.lineList2d.sky = this.get_astronomical();
+        this.lineList2d.decay = this.decay;
+        this.lineList2d.timeSeries = this.timeSeries;
+        this.lineList2d.showFarSide = this.get_showFarSide();
+        this.lineList2d.jNow = jNow;
+        this.lineList2d.drawLines(renderContext, opacity * this.get_opacity());
+    }
+    return true;
+}

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -759,6 +759,8 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         this.pointList.timeSeries = this.timeSeries;
         this.pointList.jNow = jNow;
         this.pointList.scale = (this._markerScale$1 === 1) ? adjustedScale : -adjustedScale;
+        // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/depthMask
+        renderContext.gl.depthMask(false) // we're depth buffered, but no writing to it. works, buuuuuuut??????
         switch (this._plotType$1) {
             case 0:
                 this.pointList.draw(renderContext, opacity * this.get_opacity(), false);
@@ -779,6 +781,7 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
             default:
                 break;
         }
+        renderContext.gl.depthMask(true);
     }
     if (this.lineList != null) {
         this.lineList.sky = this.get_astronomical();

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -771,6 +771,7 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
         // *** so then in a pixel - every point in that pixel get's drawn at the same depth, 
         // **** according to where this layer is in the order?
         // with shallowLayerTest always returning true, this renders properly
+        // const ogDepthMaskValue = renderContext.gl.getParameter(renderContext.gl.DEPTH_WRITEMASK)
         renderContext.gl.depthMask(false)
         switch (this._plotType$1) {
             case 0:
@@ -792,7 +793,9 @@ export function spreadSheetLayerDraw(renderContext, opacity, flat) {
             default:
                 break;
         }
-        renderContext.gl.depthMask(true);
+        // renderContext.gl.depthMask(ogDepthMaskValue);
+        renderContext.gl.depthMask(true); // checked. ogDepthMaskValue is true
+        
     }
     if (this.lineList != null) {
         this.lineList.sky = this.get_astronomical();


### PR DESCRIPTION

## Depth ordering 
This builds off of @Carifio24's re-ordering of the layer draw order. Added `SpreadSheetLayer.draw` to `wwt-hacks`
1)  set `this.pointList.depthBuffered = true;`.
2) set `shallowLayerTest` to just be `(layer) => true`. (We always want the layer to load after the planets

At this point the points all are correctly ordered, _but_ they clip each other. 

3) wrap the `pointList` draw commands with `renderContext.gl.depthMask(false)`/`renderContext.gl.depthMask(true)`. _I just saw this command online and tried it. Had no clue why it worked_

I think the principle (based on links in the code comments) is: that `gl.enable(WEBGL.DEPTH_TEST`) means that we know the depth of the Planets, and so if any point falls behind the planet, it gets discarded. (drawing is done point by point, so it knows where each one is. So we don't need to chunk the data anymore). Toggling `gl.depthMask` makes sure the points don't write their depth to depth buffer so they never clip each other. 

The solution seems to work here, I don't know if it s a general solution, as I don't know if it will break. The web engine never uses `gl.depthMask`, but it's been supported since 2015. 

## What it breaks
This does break something though. The planet points (drawn with `TimeSeriesPointSpriteShader`, same as the `SpreadSheetLayer`, both use `PointList`) now ignore their transparency. 
<img width="927" height="389" alt="image" src="https://github.com/user-attachments/assets/00f7c8cf-d64a-42ae-8d4b-280155a305e7" />

I could not figure out a combination of the two commands to fix this. 